### PR TITLE
Removing duplicate dependencies to placate bundler >= 1.10

### DIFF
--- a/pg_sequencer.gemspec
+++ b/pg_sequencer.gemspec
@@ -16,9 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  # s.add_dependency "rails", "~> 3.1.0"
-  s.add_dependency 'activerecord', '>= 3.0.0'
-  s.add_development_dependency 'activerecord', '>= 3.1.0'
+  s.add_dependency 'activerecord', '>= 3.1.0'
   s.add_development_dependency "pg", "0.11.0"
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-test"


### PR DESCRIPTION
If you are running bundler 1.10.x you'll receive the following error:

```
The gemspec at /Users/<you>/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/pg_sequencer-bf1ea069154c/pg_sequencer.gemspec is not valid. The validation error was 'duplicate dependency on activerecord (>= 3.1.0, development), (>= 3.0.0) use:
    add_runtime_dependency 'activerecord', '>= 3.1.0', '>= 3.0.0'
```

By removing the same gem, different in development and usage, we resolve the error and solidify the gem that should be used in both versions.
## To Test
- Point your Gemfile to this branch `gem 'pg_sequencer', github: 'thinkthroughmath/pg_sequencer', branch: 'mrm/fixing-gemspec'`
- `bundle install`
- Run test suite
